### PR TITLE
Add .gitignore for Arduino build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Arduino build output directories
+build/
+*.pio/
+
+# Firmware binaries
+*.elf
+*.bin
+*.hex
+
+# Logs
+*.log


### PR DESCRIPTION
## Summary
- ignore Arduino build outputs like `build/` and PlatformIO `.pio/`
- ignore firmware binaries
- ignore temporary log files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856e523788883269d90c938a1cae3b7